### PR TITLE
Ruby 1.9.2 issue

### DIFF
--- a/lib/hetzner/bootstrap/target.rb
+++ b/lib/hetzner/bootstrap/target.rb
@@ -144,7 +144,7 @@ module Hetzner
         if @public_keys
           remote do |ssh|
             ssh.exec!("mkdir /root/.ssh")
-            @public_keys.to_a.each do |key|
+            @public_keys.split("\n").each do |key|
               pub = File.read(File.expand_path(key))
               ssh.exec!("echo \"#{pub}\" >> /root/.ssh/authorized_keys")
             end


### PR DESCRIPTION
in 1.9.2 gibt es ein to_a mehr für String
