### PR TITLE
fix Error opening terminal: unknown. with recent installimage script

### DIFF
--- a/lib/hetzner/bootstrap/target.rb
+++ b/lib/hetzner/bootstrap/target.rb
@@ -23,7 +23,7 @@ module Hetzner
         @rescue_os     = 'linux'
         @rescue_os_bit = '64'
         @retries       = 0
-        @bootstrap_cmd = '/root/.oldroot/nfs/install/installimage -a -c /tmp/template'
+        @bootstrap_cmd = 'export TERM=xterm; /root/.oldroot/nfs/install/installimage -a -c /tmp/template'
         @login         = 'root'
 
         if tmpl = options.delete(:template)


### PR DESCRIPTION
Added export TERM=xterm before running the installimage command.

Hetzner uses a tool that requires a term in the current installimage script.
